### PR TITLE
fix: index out of bound at readSync when offset is non-zero

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -620,7 +620,7 @@ export class PreloadFile<FS extends FileSystem> extends File {
 			// No copy/read. Return immediatly for better performance
 			return bytesRead;
 		}
-		new Uint8Array(buffer.buffer, 0, length).set(this._buffer.slice(position, end), offset);
+		new Uint8Array(buffer.buffer, offset, length).set(this._buffer.slice(position, end));
 		return bytesRead;
 	}
 

--- a/tests/fs/read.test.ts
+++ b/tests/fs/read.test.ts
@@ -53,4 +53,13 @@ describe('read buffer', () => {
 		expect(bufferSync.toString()).toBe(expected);
 		expect(bytesRead).toBe(expected.length);
 	});
+
+	test('read file synchronously to non-zero offset', async () => {
+		const fd = fs.openSync(filepath, 'r');
+		const buffer = Buffer.alloc(expected.length + 10);
+		const bytesRead = fs.readSync(fd, buffer, 10, expected.length, 0);
+
+		expect(buffer.subarray(10, buffer.length).toString()).toBe(expected);
+		expect(bytesRead).toBe(expected.length);
+	});
 });


### PR DESCRIPTION
The added test will fail without this change.