### PR TITLE
Define Dirent.parentPath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.12.5",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "^20.12.5",
+				"@types/node": "^20.12.12",
 				"@types/readable-stream": "^4.0.10",
 				"buffer": "^6.0.3",
 				"eventemitter3": "^5.0.1",
@@ -2000,9 +2000,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.12.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
-			"integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+			"version": "20.12.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+			"integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -8463,9 +8463,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "20.12.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
-			"integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+			"version": "20.12.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+			"integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
 			"requires": {
 				"undici-types": "~5.26.4"
 			}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"prepublishOnly": "npm run build"
 	},
 	"dependencies": {
-		"@types/node": "^20.12.5",
+		"@types/node": "^20.12.12",
 		"@types/readable-stream": "^4.0.10",
 		"buffer": "^6.0.3",
 		"eventemitter3": "^5.0.1",

--- a/src/emulation/dir.ts
+++ b/src/emulation/dir.ts
@@ -16,6 +16,10 @@ export class Dirent implements _Dirent {
 		protected stats: Stats
 	) {}
 
+	get parentPath(): string {
+		return this.path;
+	}
+
 	isFile(): boolean {
 		return this.stats.isFile();
 	}


### PR DESCRIPTION
`Dirent.parentPath` is introduced in Node.js v21.4.0, v20.12.0, v18.20.0 as a replacement of `Dirent.path`.