### PR TITLE
test requires build

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"lint": "eslint src tests",
 		"test:common": "tsx --test --experimental-test-coverage 'tests/**/!(fs)/*.test.ts' 'tests/*.test.ts'",
 		"test": "tsx --test --experimental-test-coverage",
+		"pretest": "npm run build",
 		"build": "tsc -p tsconfig.json",
 		"build:docs": "typedoc",
 		"dev": "npm run build -- --watch",


### PR DESCRIPTION
Since `test` requires `build` first, this will automate, which allows `npm it` to install/test (basically the first thing I run when I am looking at a lib.)