### PR TITLE
shows must create mounted dirs

### DIFF
--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'node:path';
-import { fs } from '../dist/index.js';
+import { fs, configure, InMemory } from '../dist/index.js';
 
 const setupPath = resolve(process.env.SETUP || join(import.meta.dirname, 'setup/memory.ts'));
 
@@ -8,4 +8,4 @@ await import(setupPath).catch(error => {
 	throw error;
 });
 
-export { fs };
+export { fs, configure, InMemory };

--- a/tests/fs/readdir.test.ts
+++ b/tests/fs/readdir.test.ts
@@ -18,18 +18,18 @@ for (const dir of testDirectories) {
 }
 
 // must make any dirs that are mounted
-fs.mkdirSync('/mnt/tester', { recursive: true })
-fs.mkdirSync('/deep/stuff/here', { recursive: true })
-fs.mkdirSync('/top')
+fs.mkdirSync('/mnt/tester', { recursive: true });
+fs.mkdirSync('/deep/stuff/here', { recursive: true });
+fs.mkdirSync('/top');
 
 await configure({
 	mounts: {
 		'/mnt/tester': InMemory,
 		'/deep/stuff/here': InMemory,
-		'/top': InMemory
-	}
-})
-fs.writeFileSync('/deep/stuff/here/gotcha.txt', 'Hi!')
+		'/top': InMemory,
+	},
+});
+fs.writeFileSync('/deep/stuff/here/gotcha.txt', 'Hi!');
 
 suite('readdir and readdirSync', () => {
 	test('readdir returns files and directories', async () => {
@@ -100,7 +100,7 @@ suite('readdir and readdirSync', () => {
 	});
 
 	test('readdir from a new mount (recursive)', () => {
-		const entries = fs.readdirSync('/', {recursive: true})
-  	assert(entries.includes('deep/stuff/here/gotcha.txt'));
+		const entries = fs.readdirSync('/', { recursive: true });
+		assert(entries.includes('deep/stuff/here/gotcha.txt'));
 	});
 });


### PR DESCRIPTION
I did not realize I needed to create directories before mounting them. This illustrates that. See #127 

In addition to the actual small test, I had to do some setup, and export a few more things from `common` to allow me to make a new mount. Maybe this should go in another test file, though, since it's really more about mounting.