### PR TITLE
Fixes access check and properly handling GID set

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1,6 +1,6 @@
 import type { FileReadResult } from 'node:fs/promises';
-import { O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, O_SYNC, O_TRUNC, O_WRONLY, S_IFMT, size_max } from './emulation/constants.js';
 import { config } from './emulation/config.js';
+import { O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, O_SYNC, O_TRUNC, O_WRONLY, S_IFMT, size_max } from './emulation/constants.js';
 import { Errno, ErrnoError } from './error.js';
 import type { FileSystem } from './filesystem.js';
 import './polyfills.js';

--- a/src/inode.ts
+++ b/src/inode.ts
@@ -1,5 +1,5 @@
+import { deserialize, serialize, sizeof, struct, types as t } from 'utilium';
 import { Stats, type StatsLike } from './stats.js';
-import { types as t, struct, sizeof, serialize, deserialize } from 'utilium';
 
 /**
  * Alias for an ino.
@@ -108,8 +108,8 @@ export class Inode implements StatsLike {
 			hasChanged = true;
 		}
 
-		if (this.uid !== stats.uid) {
-			this.uid = stats.uid;
+		if (this.gid !== stats.gid) {
+			this.gid = stats.gid;
 			hasChanged = true;
 		}
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -244,24 +244,28 @@ export abstract class StatsCommon<T extends number | bigint> implements Node.Sta
 	 */
 	public hasAccess(mode: number): boolean {
 		if (credentials.euid === 0 || credentials.egid === 0) {
-			//Running as root
+			// Running as root
 			return true;
 		}
 
 		let perm = 0;
 
+		// Owner permissions
 		if (credentials.uid === this.uid) {
-			// Owner permissions
 			if (this.mode & S_IRUSR) perm |= R_OK;
 			if (this.mode & S_IWUSR) perm |= W_OK;
 			if (this.mode & S_IXUSR) perm |= X_OK;
-		} else if (credentials.gid === this.gid) {
-			// Group permissions
+		}
+
+		// Group permissions
+		if (credentials.gid === this.gid) {
 			if (this.mode & S_IRGRP) perm |= R_OK;
 			if (this.mode & S_IWGRP) perm |= W_OK;
 			if (this.mode & S_IXGRP) perm |= X_OK;
-		} else {
-			// Others permissions
+		}
+
+		// Others permissions
+		if (credentials.uid !== this.uid && credentials.gid !== this.gid) {
 			if (this.mode & S_IROTH) perm |= R_OK;
 			if (this.mode & S_IWOTH) perm |= W_OK;
 			if (this.mode & S_IXOTH) perm |= X_OK;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -265,11 +265,9 @@ export abstract class StatsCommon<T extends number | bigint> implements Node.Sta
 		}
 
 		// Others permissions
-		if (credentials.uid !== this.uid && credentials.gid !== this.gid) {
-			if (this.mode & S_IROTH) perm |= R_OK;
-			if (this.mode & S_IWOTH) perm |= W_OK;
-			if (this.mode & S_IXOTH) perm |= X_OK;
-		}
+		if (this.mode & S_IROTH) perm |= R_OK;
+		if (this.mode & S_IWOTH) perm |= W_OK;
+		if (this.mode & S_IXOTH) perm |= X_OK;
 
 		// Perform the access check
 		return (perm & mode) === mode;


### PR DESCRIPTION
I found a bug where GID isn't being set because it was being compared to uid twice

<img width="407" alt="image" src="https://github.com/user-attachments/assets/c31ec4e0-027e-4b0b-87a5-53f335ff4200">

