### PR TITLE
Lazy files

### DIFF
--- a/src/backends/file_index.ts
+++ b/src/backends/file_index.ts
@@ -148,6 +148,14 @@ export abstract class IndexFS extends Readonly(FileSystem) {
 		return this.index.get(path)!;
 	}
 
+	public async readFile(path: string): Promise<Uint8Array> {
+		return this.getData(path, await this.stat(path));
+	}
+
+	public readFileSync(path: string): Uint8Array {
+		return this.getDataSync(path, this.statSync(path));
+	}
+
 	public async openFile(path: string, flag: string): Promise<NoSyncFile<this>> {
 		if (isWriteable(flag)) {
 			// You can't write to files on this file system.

--- a/src/backends/overlay.ts
+++ b/src/backends/overlay.ts
@@ -204,6 +204,20 @@ export class UnmutexedOverlayFS extends FileSystem {
 		return new PreloadFile(this, path, flag, stats, data);
 	}
 
+	public async readFile(path: string): Promise<Uint8Array> {
+		if (await this.writable.exists(path)) {
+			return this.writable.readFile(path);
+		}
+		return this.readable.readFile(path);
+	}
+
+	public readFileSync(path: string): Uint8Array {
+		if (this.writable.existsSync(path)) {
+			return this.writable.readFileSync(path);
+		}
+		return this.readable.readFileSync(path);
+	}
+
 	public async createFile(path: string, flag: string, mode: number): Promise<File> {
 		this.checkInitialized();
 		await this.writable.createFile(path, flag, mode);

--- a/src/backends/overlay.ts
+++ b/src/backends/overlay.ts
@@ -72,7 +72,7 @@ export class UnmutexedOverlayFS extends FileSystem {
 		};
 	}
 
-	public async sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void> {
+	public async sync(path: string, data: Uint8Array | false, stats: Readonly<Stats>): Promise<void> {
 		await this.copyForWrite(path);
 		if (!(await this.writable.exists(path))) {
 			await this.writable.createFile(path, 'w', 0o644);
@@ -80,7 +80,7 @@ export class UnmutexedOverlayFS extends FileSystem {
 		await this.writable.sync(path, data, stats);
 	}
 
-	public syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void {
+	public syncSync(path: string, data: Uint8Array | false, stats: Readonly<Stats>): void {
 		this.copyForWriteSync(path);
 		this.writable.syncSync(path, data, stats);
 	}

--- a/src/backends/overlay.ts
+++ b/src/backends/overlay.ts
@@ -72,7 +72,7 @@ export class UnmutexedOverlayFS extends FileSystem {
 		};
 	}
 
-	public async sync(path: string, data: Uint8Array | false, stats: Readonly<Stats>): Promise<void> {
+	public async sync(path: string, data?: Uint8Array, stats: Readonly<Partial<Stats>> = {}): Promise<void> {
 		await this.copyForWrite(path);
 		if (!(await this.writable.exists(path))) {
 			await this.writable.createFile(path, 'w', 0o644);
@@ -80,7 +80,7 @@ export class UnmutexedOverlayFS extends FileSystem {
 		await this.writable.sync(path, data, stats);
 	}
 
-	public syncSync(path: string, data: Uint8Array | false, stats: Readonly<Stats>): void {
+	public syncSync(path: string, data?: Uint8Array, stats: Readonly<Partial<Stats>> = {}): void {
 		this.copyForWriteSync(path);
 		this.writable.syncSync(path, data, stats);
 	}

--- a/src/backends/port/fs.ts
+++ b/src/backends/port/fs.ts
@@ -21,9 +21,9 @@ export interface FileRequest<TMethod extends FileMethod = FileMethod> extends RP
 	args: Parameters<FileMethods[TMethod]>;
 }
 
-export class PortFile extends File {
+export class PortFile extends File<PortFS> {
 	public constructor(
-		public fs: PortFS,
+		fs: PortFS,
 		public readonly fd: number,
 		path: string,
 		public position: number
@@ -192,7 +192,7 @@ export class PortFS extends Async(FileSystem) {
 		return new Stats(await this.rpc('stat', path));
 	}
 
-	public sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void> {
+	public sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
 		return this.rpc('sync', path, data, stats);
 	}
 

--- a/src/backends/port/fs.ts
+++ b/src/backends/port/fs.ts
@@ -200,6 +200,10 @@ export class PortFS extends Async(FileSystem) {
 		return this.rpc('openFile', path, flag);
 	}
 
+	public readFile(path: string): Promise<Uint8Array> {
+		return this.rpc('readFile', path);
+	}
+
 	public createFile(path: string, flag: string, mode: number): Promise<File> {
 		return this.rpc('createFile', path, flag, mode);
 	}

--- a/src/backends/port/fs.ts
+++ b/src/backends/port/fs.ts
@@ -184,7 +184,7 @@ export class PortFS extends Async(FileSystem) {
 		return new Stats(await this.rpc('stat', path));
 	}
 
-	public sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
+	public sync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): Promise<void> {
 		return this.rpc('sync', path, data, stats);
 	}
 

--- a/src/backends/port/fs.ts
+++ b/src/backends/port/fs.ts
@@ -104,14 +104,6 @@ export class PortFile extends File<PortFS> {
 		this._throwNoSync('utimes');
 	}
 
-	public _setType(type: FileType): Promise<void> {
-		return this.rpc('_setType', type);
-	}
-
-	public _setTypeSync(): void {
-		this._throwNoSync('_setType');
-	}
-
 	public close(): Promise<void> {
 		return this.rpc('close');
 	}

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -196,6 +196,21 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 		return new PreloadFile(this, path, flag, node.toStats(), data);
 	}
 
+	public async readFile(path: string): Promise<Uint8Array> {
+		await using tx = this.store.transaction();
+		const node = await this.findInode(tx, path, 'read');
+		const data = await this.get(tx, node.data, path, 'read');
+		return data;
+	}
+
+	public readFileSync(path: string): Uint8Array {
+		using tx = this.store.transaction();
+		const node = this.findInodeSync(tx, path, 'openFile');
+		const data = this.getSync(tx, node.data, path, 'openFile');
+
+		return data;
+	}
+
 	public async unlink(path: string): Promise<void> {
 		return this.remove(path, false, 'unlink');
 	}

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -257,7 +257,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 	 * Updated the inode and data node at `path`
 	 * @todo Ensure mtime updates properly, and use that to determine if a data update is required.
 	 */
-	public async sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void> {
+	public async sync(path: string, data?: Uint8Array | false, stats: Readonly<Partial<Stats>> = {}): Promise<void> {
 		await using tx = this.store.transaction();
 		// We use _findInode because we actually need the INode id.
 		const fileInodeId = await this._findInode(tx, path, 'sync'),
@@ -265,7 +265,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 			inodeChanged = fileInode.update(stats);
 
 		// Sync data.
-		await tx.set(fileInode.data, data);
+		if (data) await tx.set(fileInode.data, data);
 		// Sync metadata.
 		if (inodeChanged) {
 			await tx.set(fileInodeId, serialize(fileInode));
@@ -278,7 +278,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 	 * Updated the inode and data node at `path`
 	 * @todo Ensure mtime updates properly, and use that to determine if a data update is required.
 	 */
-	public syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void {
+	public syncSync(path: string, data?: Uint8Array | false, stats: Readonly<Partial<Stats>> = {}): void {
 		using tx = this.store.transaction();
 		// We use _findInode because we actually need the INode id.
 		const fileInodeId = this._findInodeSync(tx, path, 'sync'),
@@ -286,7 +286,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 			inodeChanged = fileInode.update(stats);
 
 		// Sync data.
-		tx.setSync(fileInode.data, data);
+		if (data) tx.setSync(fileInode.data, data);
 		// Sync metadata.
 		if (inodeChanged) {
 			tx.setSync(fileInodeId, serialize(fileInode));

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -257,7 +257,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 	 * Updated the inode and data node at `path`
 	 * @todo Ensure mtime updates properly, and use that to determine if a data update is required.
 	 */
-	public async sync(path: string, data?: Uint8Array | false, stats: Readonly<Partial<Stats>> = {}): Promise<void> {
+	public async sync(path: string, data?: Uint8Array, stats: Readonly<Partial<Stats>> = {}): Promise<void> {
 		await using tx = this.store.transaction();
 		// We use _findInode because we actually need the INode id.
 		const fileInodeId = await this._findInode(tx, path, 'sync'),
@@ -278,7 +278,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 	 * Updated the inode and data node at `path`
 	 * @todo Ensure mtime updates properly, and use that to determine if a data update is required.
 	 */
-	public syncSync(path: string, data?: Uint8Array | false, stats: Readonly<Partial<Stats>> = {}): void {
+	public syncSync(path: string, data?: Uint8Array, stats: Readonly<Partial<Stats>> = {}): void {
 		using tx = this.store.transaction();
 		// We use _findInode because we actually need the INode id.
 		const fileInodeId = this._findInodeSync(tx, path, 'sync'),

--- a/src/devices.ts
+++ b/src/devices.ts
@@ -391,14 +391,14 @@ export class DeviceFS extends StoreFS<InMemoryStore> {
 		return super.linkSync(target, link);
 	}
 
-	public async sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
+	public async sync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): Promise<void> {
 		if (this.devices.has(path)) {
 			throw new ErrnoError(Errno.EINVAL, 'Attempted to sync a device incorrectly (bug)', path, 'sync');
 		}
 		return super.sync(path, data, stats);
 	}
 
-	public syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void {
+	public syncSync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): void {
 		if (this.devices.has(path)) {
 			throw new ErrnoError(Errno.EINVAL, 'Attempted to sync a device incorrectly (bug)', path, 'sync');
 		}

--- a/src/devices.ts
+++ b/src/devices.ts
@@ -208,14 +208,6 @@ export class DeviceFile extends File {
 	public utimesSync(): void {
 		throw ErrnoError.With('ENOTSUP', this.path, 'utimes');
 	}
-
-	public _setType(): Promise<void> {
-		throw ErrnoError.With('ENOTSUP', this.path, '_setType');
-	}
-
-	public _setTypeSync(): void {
-		throw ErrnoError.With('ENOTSUP', this.path, '_setType');
-	}
 }
 
 /**

--- a/src/devices.ts
+++ b/src/devices.ts
@@ -399,14 +399,14 @@ export class DeviceFS extends StoreFS<InMemoryStore> {
 		return super.linkSync(target, link);
 	}
 
-	public async sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void> {
+	public async sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
 		if (this.devices.has(path)) {
 			throw new ErrnoError(Errno.EINVAL, 'Attempted to sync a device incorrectly (bug)', path, 'sync');
 		}
 		return super.sync(path, data, stats);
 	}
 
-	public syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void {
+	public syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void {
 		if (this.devices.has(path)) {
 			throw new ErrnoError(Errno.EINVAL, 'Attempted to sync a device incorrectly (bug)', path, 'sync');
 		}

--- a/src/emulation/promises.ts
+++ b/src/emulation/promises.ts
@@ -822,7 +822,7 @@ export async function symlink(target: fs.PathLike, path: fs.PathLike, type: fs.s
 
 	await using handle = await _open(path, 'w+', 0o644, false);
 	await handle.writeFile(target.toString());
-	await handle.file._setType(constants.S_IFLNK);
+	await handle.file.chmod(constants.S_IFLNK);
 }
 symlink satisfies typeof promises.symlink;
 

--- a/src/emulation/sync.ts
+++ b/src/emulation/sync.ts
@@ -550,7 +550,7 @@ export function symlinkSync(target: fs.PathLike, path: fs.PathLike, type: fs.sym
 
 	writeFileSync(path, target.toString());
 	const file = _openSync(path, 'r+', 0o644, false);
-	file._setTypeSync(constants.S_IFLNK);
+	file.chmodSync(constants.S_IFLNK);
 }
 symlinkSync satisfies typeof fs.symlinkSync;
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -172,6 +172,6 @@ export abstract class FileSystem {
 	public abstract link(target: string, link: string): Promise<void>;
 	public abstract linkSync(target: string, link: string): void;
 
-	public abstract sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void>;
-	public abstract syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void;
+	public abstract sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void>;
+	public abstract syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void;
 }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -172,6 +172,6 @@ export abstract class FileSystem {
 	public abstract link(target: string, link: string): Promise<void>;
 	public abstract linkSync(target: string, link: string): void;
 
-	public abstract sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void>;
-	public abstract syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void;
+	public abstract sync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): Promise<void>;
+	public abstract syncSync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): void;
 }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -118,6 +118,9 @@ export abstract class FileSystem {
 	 */
 	public abstract openFileSync(path: string, flag: string): File;
 
+	public abstract readFile(path: string): Promise<Uint8Array>;
+	public abstract readFileSync(path: string): Uint8Array;
+
 	/**
 	 * Create the file at `path` with `mode`. Then, open it with `flag`.
 	 */

--- a/src/inode.ts
+++ b/src/inode.ts
@@ -82,45 +82,14 @@ export class Inode implements StatsLike {
 	 *   file system.
 	 * @return True if any changes have occurred.
 	 */
-	public update(stats: Readonly<Stats>): boolean {
+	public update(stats: Readonly<Partial<Stats>>): boolean {
 		let hasChanged = false;
-		if (this.size !== stats.size) {
-			this.size = stats.size;
-			hasChanged = true;
-		}
 
-		if (this.mode !== stats.mode) {
-			this.mode = stats.mode;
-			hasChanged = true;
-		}
-
-		if (this.nlink !== stats.nlink) {
-			this.nlink = stats.nlink;
-			hasChanged = true;
-		}
-
-		if (this.uid !== stats.uid) {
-			this.uid = stats.uid;
-			hasChanged = true;
-		}
-
-		if (this.gid !== stats.gid) {
-			this.gid = stats.gid;
-			hasChanged = true;
-		}
-
-		if (this.atimeMs !== stats.atimeMs) {
-			this.atimeMs = stats.atimeMs;
-			hasChanged = true;
-		}
-		if (this.mtimeMs !== stats.mtimeMs) {
-			this.mtimeMs = stats.mtimeMs;
-			hasChanged = true;
-		}
-
-		if (this.ctimeMs !== stats.ctimeMs) {
-			this.ctimeMs = stats.ctimeMs;
-			hasChanged = true;
+		for (const key of ['size', 'mode', 'nlink', 'uid', 'gid', 'atimeMs', 'mtimeMs', 'ctimeMs'] as const satisfies (keyof StatsLike)[]) {
+			if (stats[key] !== undefined && stats[key] !== null && this[key] !== stats[key]) {
+				this[key] = stats[key];
+				hasChanged = true;
+			}
 		}
 
 		return hasChanged;

--- a/src/mixins/async.ts
+++ b/src/mixins/async.ts
@@ -32,7 +32,7 @@ export interface Async {
 	mkdirSync(path: string, mode: number): void;
 	readdirSync(path: string): string[];
 	linkSync(srcpath: string, dstpath: string): void;
-	syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void;
+	syncSync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): void;
 }
 
 /**
@@ -171,7 +171,7 @@ export function Async<const T extends typeof FileSystem>(FS: T): Mixin<T, Async>
 			this.queue('link', srcpath, dstpath);
 		}
 
-		public syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void {
+		public syncSync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): void {
 			this.checkSync(path, 'sync');
 			this._sync.syncSync(path, data, stats);
 			this.queue('sync', path, data, stats);

--- a/src/mixins/async.ts
+++ b/src/mixins/async.ts
@@ -26,6 +26,7 @@ export interface Async {
 	statSync(path: string): Stats;
 	createFileSync(path: string, flag: string, mode: number): File;
 	openFileSync(path: string, flag: string): File;
+	readFileSync(path: string): Uint8Array;
 	unlinkSync(path: string): void;
 	rmdirSync(path: string): void;
 	mkdirSync(path: string, mode: number): void;
@@ -134,6 +135,11 @@ export function Async<const T extends typeof FileSystem>(FS: T): Mixin<T, Async>
 			const buffer = new Uint8Array(stats.size);
 			file.readSync(buffer);
 			return new PreloadFile(this, path, flag, stats, buffer);
+		}
+
+		public readFileSync(path: string): Uint8Array {
+			this.checkSync(path, 'readFile');
+			return this._sync.readFileSync(path);
 		}
 
 		public unlinkSync(path: string): void {

--- a/src/mixins/async.ts
+++ b/src/mixins/async.ts
@@ -32,7 +32,7 @@ export interface Async {
 	mkdirSync(path: string, mode: number): void;
 	readdirSync(path: string): string[];
 	linkSync(srcpath: string, dstpath: string): void;
-	syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void;
+	syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void;
 }
 
 /**
@@ -171,7 +171,7 @@ export function Async<const T extends typeof FileSystem>(FS: T): Mixin<T, Async>
 			this.queue('link', srcpath, dstpath);
 		}
 
-		public syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void {
+		public syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void {
 			this.checkSync(path, 'sync');
 			this._sync.syncSync(path, data, stats);
 			this.queue('sync', path, data, stats);

--- a/src/mixins/mutexed.ts
+++ b/src/mixins/mutexed.ts
@@ -221,12 +221,12 @@ export class _MutexedFS<T extends FileSystem> implements FileSystem {
 		return this._fs.linkSync(srcpath, dstpath);
 	}
 
-	public async sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
+	public async sync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): Promise<void> {
 		using _ = await this.lock(path, 'sync');
 		await this._fs.sync(path, data, stats);
 	}
 
-	public syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void {
+	public syncSync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): void {
 		using _ = this.lockSync(path, 'sync');
 		return this._fs.syncSync(path, data, stats);
 	}

--- a/src/mixins/mutexed.ts
+++ b/src/mixins/mutexed.ts
@@ -221,12 +221,12 @@ export class _MutexedFS<T extends FileSystem> implements FileSystem {
 		return this._fs.linkSync(srcpath, dstpath);
 	}
 
-	public async sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void> {
+	public async sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
 		using _ = await this.lock(path, 'sync');
 		await this._fs.sync(path, data, stats);
 	}
 
-	public syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void {
+	public syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void {
 		using _ = this.lockSync(path, 'sync');
 		return this._fs.syncSync(path, data, stats);
 	}

--- a/src/mixins/mutexed.ts
+++ b/src/mixins/mutexed.ts
@@ -137,6 +137,16 @@ export class _MutexedFS<T extends FileSystem> implements FileSystem {
 		return file;
 	}
 
+	public async readFile(path: string): Promise<Uint8Array> {
+		using _ = await this.lock(path, 'readFile');
+		return await this._fs.readFile(path);
+	}
+
+	public readFileSync(path: string): Uint8Array {
+		using _ = this.lockSync(path, 'readFile');
+		return this._fs.readFileSync(path);
+	}
+
 	public async createFile(path: string, flag: string, mode: number): Promise<File> {
 		using _ = await this.lock(path, 'createFile');
 		const file = await this._fs.createFile(path, flag, mode);

--- a/src/mixins/readonly.ts
+++ b/src/mixins/readonly.ts
@@ -26,8 +26,8 @@ export function Readonly<T extends typeof FileSystem>(
 		mkdirSync(path: string, mode: number): void;
 		link(srcpath: string, dstpath: string): Promise<void>;
 		linkSync(srcpath: string, dstpath: string): void;
-		sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void>;
-		syncSync(path: string, data: Uint8Array, stats: Readonly<Stats>): void;
+		sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void>;
+		syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void;
 	}
 > {
 	abstract class ReadonlyFS extends FS {

--- a/src/mixins/readonly.ts
+++ b/src/mixins/readonly.ts
@@ -26,8 +26,8 @@ export function Readonly<T extends typeof FileSystem>(
 		mkdirSync(path: string, mode: number): void;
 		link(srcpath: string, dstpath: string): Promise<void>;
 		linkSync(srcpath: string, dstpath: string): void;
-		sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void>;
-		syncSync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): void;
+		sync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): Promise<void>;
+		syncSync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): void;
 	}
 > {
 	abstract class ReadonlyFS extends FS {

--- a/src/mixins/sync.ts
+++ b/src/mixins/sync.ts
@@ -49,7 +49,7 @@ export function Sync<T extends typeof FileSystem>(FS: T): Mixin<T, AsyncFSMethod
 			return this.linkSync(srcpath, dstpath);
 		}
 
-		public async sync(path: string, data: Uint8Array, stats: Readonly<Stats>): Promise<void> {
+		public async sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
 			return this.syncSync(path, data, stats);
 		}
 	}

--- a/src/mixins/sync.ts
+++ b/src/mixins/sync.ts
@@ -49,7 +49,7 @@ export function Sync<T extends typeof FileSystem>(FS: T): Mixin<T, AsyncFSMethod
 			return this.linkSync(srcpath, dstpath);
 		}
 
-		public async sync(path: string, data?: Uint8Array | false, stats?: Readonly<Partial<Stats>>): Promise<void> {
+		public async sync(path: string, data?: Uint8Array, stats?: Readonly<Partial<Stats>>): Promise<void> {
 			return this.syncSync(path, data, stats);
 		}
 	}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -67,6 +67,10 @@ export interface StatsLike<T extends number | bigint = number | bigint> {
 	 * Inode number
 	 */
 	ino: T;
+	/**
+	 * Number of hard links
+	 */
+	nlink: T;
 }
 
 /**
@@ -292,6 +296,7 @@ export abstract class StatsCommon<T extends number | bigint> implements Node.Sta
 	 * Change the mode of the file.
 	 * We use this helper function to prevent messing up the type of the file.
 	 * @internal
+	 * @deprecated This will be removed in the next minor release since it is internal
 	 */
 	public chmod(mode: number): void {
 		this.mode = this._convert((this.mode & S_IFMT) | mode);
@@ -301,8 +306,9 @@ export abstract class StatsCommon<T extends number | bigint> implements Node.Sta
 	 * Change the owner user/group of the file.
 	 * This function makes sure it is a valid UID/GID (that is, a 32 unsigned int)
 	 * @internal
+	 * @deprecated This will be removed in the next minor release since it is internal
 	 */
-	public chown(uid: number | bigint, gid: number | bigint): void {
+	public chown(uid: number, gid: number): void {
 		uid = Number(uid);
 		gid = Number(gid);
 		if (!isNaN(uid) && 0 <= uid && uid < 2 ** 32) {
@@ -327,6 +333,18 @@ export abstract class StatsCommon<T extends number | bigint> implements Node.Sta
 
 	public get birthtimeNs(): bigint {
 		return BigInt(this.birthtimeMs) * 1000n;
+	}
+}
+
+/**
+ * @hidden @internal
+ */
+export function _chown(stats: Partial<StatsLike<number>>, uid: number, gid: number) {
+	if (!isNaN(uid) && 0 <= uid && uid < 2 ** 32) {
+		stats.uid = uid;
+	}
+	if (!isNaN(gid) && 0 <= gid && gid < 2 ** 32) {
+		stats.gid = gid;
 	}
 }
 


### PR DESCRIPTION
This PR tracks progress on implementing lazy files. `LazyFile` is a new `File` class that only reads and stats the file when it is needed, unlike `PreloadFile` which aggressively preloads a file's stats and data. `LazyFile` should reduce memory usage and may also lead to performance gains, though that remains to be tested.