### PR TITLE
Defaulting to utf-8 when encoding is not present

### DIFF
--- a/src/emulation/promises.ts
+++ b/src/emulation/promises.ts
@@ -20,8 +20,8 @@ import { Dir, Dirent } from './dir.js';
 import { dirname, join, parse, resolve } from './path.js';
 import { _statfs, fd2file, fdMap, file2fd, fixError, resolveMount } from './shared.js';
 import { ReadStream, WriteStream } from './streams.js';
-import { FSWatcher, emitChange } from './watchers.js';
 import type { GlobOptionsU, InternalOptions, NullEnc, ReaddirOptions, ReaddirOptsI, ReaddirOptsU } from './types.js';
+import { FSWatcher, emitChange } from './watchers.js';
 export * as constants from './constants.js';
 
 export class FileHandle implements promises.FileHandle {
@@ -857,7 +857,8 @@ export async function readlink(this: V_Context, path: fs.PathLike, options?: fs.
 	await using handle = await _open.call(this, normalizePath(path), 'r', 0o644, false);
 	const value = await handle.readFile();
 	const encoding = typeof options == 'object' ? options?.encoding : options;
-	return encoding == 'buffer' ? value : value.toString(encoding! as BufferEncoding);
+	// always defaults to utf-8 to avoid wrangler (cloudflare) worker "unknown encoding" exception
+	return encoding == 'buffer' ? value : value.toString((encoding ?? 'utf-8') as BufferEncoding);
 }
 readlink satisfies typeof promises.readlink;
 

--- a/src/emulation/sync.ts
+++ b/src/emulation/sync.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer';
 import type * as fs from 'node:fs';
+import type { V_Context } from '../context.js';
 import { Errno, ErrnoError } from '../error.js';
 import type { File } from '../file.js';
 import { flagToMode, isAppendable, isExclusive, isReadable, isTruncating, isWriteable, parseFlag } from '../file.js';
@@ -12,9 +13,8 @@ import * as constants from './constants.js';
 import { Dir, Dirent } from './dir.js';
 import { dirname, join, parse, resolve } from './path.js';
 import { _statfs, fd2file, fdMap, file2fd, fixError, resolveMount } from './shared.js';
+import type { GlobOptionsU, InternalOptions, NullEnc, ReaddirOptions, ReaddirOptsI, ReaddirOptsU } from './types.js';
 import { emitChange } from './watchers.js';
-import type { V_Context } from '../context.js';
-import type { GlobOptionsU, ReaddirOptsI, ReaddirOptsU, InternalOptions, ReaddirOptions, NullEnc } from './types.js';
 
 export function renameSync(this: V_Context, oldPath: fs.PathLike, newPath: fs.PathLike): void {
 	oldPath = normalizePath(oldPath);
@@ -558,7 +558,8 @@ export function readlinkSync(this: V_Context, path: fs.PathLike, options?: fs.En
 	if (encoding == 'buffer') {
 		return value;
 	}
-	return value.toString(encoding!);
+	// always defaults to utf-8 to avoid wrangler (cloudflare) worker "unknown encoding" exception
+	return value.toString(encoding ?? 'utf-8');
 }
 readlinkSync satisfies typeof fs.readlinkSync;
 


### PR DESCRIPTION
## Description

This is a bug that only happens on CF Workers, for some reason passing `null` or `undefined` as a encoding for `buffers.toString()` does not work.

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/58d4e720-2c3f-4967-bfd1-d93bc3782f02" />


Since node defaults to `utf-8` when not present (source: https://www.w3schools.com/nodejs/met_buffer_tostring.asp) I change to use `utf-8` by default instead of passing `null/undefined`

CF Fix: https://github.com/cloudflare/workerd/pull/3252
