### PR TITLE
Add support for range requests to `Fetch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"buffer": "^6.0.3",
 				"eventemitter3": "^5.0.1",
 				"readable-stream": "^4.5.2",
-				"utilium": "^1.1.1"
+				"utilium": "^1.2.0"
 			},
 			"bin": {
 				"make-index": "scripts/make-index.js",
@@ -3335,9 +3335,9 @@
 			}
 		},
 		"node_modules/utilium": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/utilium/-/utilium-1.1.1.tgz",
-			"integrity": "sha512-uNwrjhLA+KN5/EuDJaofvRerLffPSQ1aj6uot21tCwiU2oHKWHU2F3xW+wETgjJ3JFqDIloY6zSutQRmTbjAVw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/utilium/-/utilium-1.2.0.tgz",
+			"integrity": "sha512-my5IARsgDVKJhbpIysclggvCo7x4yPVYoVRU1JO1sg8+X65uhNbG99yIHPcZ5RWiPzpCt7kWShmr7LxXBGRIiw==",
 			"license": "MIT",
 			"dependencies": {
 				"eventemitter3": "^5.0.1"
@@ -5632,9 +5632,9 @@
 			}
 		},
 		"utilium": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/utilium/-/utilium-1.1.1.tgz",
-			"integrity": "sha512-uNwrjhLA+KN5/EuDJaofvRerLffPSQ1aj6uot21tCwiU2oHKWHU2F3xW+wETgjJ3JFqDIloY6zSutQRmTbjAVw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/utilium/-/utilium-1.2.0.tgz",
+			"integrity": "sha512-my5IARsgDVKJhbpIysclggvCo7x4yPVYoVRU1JO1sg8+X65uhNbG99yIHPcZ5RWiPzpCt7kWShmr7LxXBGRIiw==",
 			"requires": {
 				"@xterm/xterm": "^5.5.0",
 				"eventemitter3": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"buffer": "^6.0.3",
 		"eventemitter3": "^5.0.1",
 		"readable-stream": "^4.5.2",
-		"utilium": "^1.1.1"
+		"utilium": "^1.2.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.8.0",

--- a/src/backends/fetch.ts
+++ b/src/backends/fetch.ts
@@ -1,7 +1,7 @@
-import { serialize } from 'utilium';
+import { GET as fetchWithRanges, type RequestError } from 'utilium/requests.js';
 import { Errno, ErrnoError } from '../error.js';
-import { err, log_deprecated } from '../log.js';
-import { growBuffer, normalizePath } from '../utils.js';
+import { err, log_deprecated, warn } from '../log.js';
+import { decodeUTF8, normalizePath } from '../utils.js';
 import { S_IFREG } from '../vfs/constants.js';
 import type { Backend, SharedConfig } from './backend.js';
 import type { IndexData } from './store/file_index.js';
@@ -9,36 +9,23 @@ import { Index } from './store/file_index.js';
 import { StoreFS } from './store/fs.js';
 import type { Store } from './store/store.js';
 import { Transaction } from './store/store.js';
+import { extendBuffer } from 'utilium/buffer.js';
 
-/**
- * Asynchronously download a file as a buffer or a JSON object.
- * Note that the third function signature with a non-specialized type is invalid,
- * but TypeScript requires it when you specialize string arguments to constants.
- * @hidden
- */
-async function fetchFile(path: string, type: 'buffer', init?: RequestInit): Promise<Uint8Array>;
-async function fetchFile<T extends object>(path: string, type: 'json', init?: RequestInit): Promise<T>;
-async function fetchFile<T extends object>(path: string, type: 'buffer' | 'json', init?: RequestInit): Promise<T | Uint8Array>;
-async function fetchFile<T extends object>(path: string, type: string, init?: RequestInit): Promise<T | Uint8Array> {
-	const response = await fetch(path, init).catch((e: Error) => {
-		throw err(new ErrnoError(Errno.EIO, e.message, path));
-	});
-	if (!response.ok) {
-		throw err(new ErrnoError(Errno.EIO, 'fetch failed: response returned code ' + response.status, path));
-	}
-	switch (type) {
-		case 'buffer': {
-			const arrayBuffer = await response.arrayBuffer().catch((e: Error) => {
-				throw new ErrnoError(Errno.EIO, e.message, path);
-			});
-			return new Uint8Array(arrayBuffer);
+/** Parse and throw */
+function parseError(error: RequestError): never {
+	if (!('tag' in error)) throw err(new ErrnoError(Errno.EIO, error.message));
+
+	switch (error.tag) {
+		case 'fetch':
+			throw err(new ErrnoError(Errno.EREMOTEIO, error.message));
+		case 'status': {
+			const { status } = error.response;
+			throw err(new ErrnoError(status > 500 ? Errno.EREMOTEIO : Errno.EIO, 'Fetch failed, response status code is ' + status));
 		}
-		case 'json':
-			return response.json().catch((e: Error) => {
-				throw new ErrnoError(Errno.EIO, e.message, path);
-			}) as Promise<T>;
-		default:
-			throw err(new ErrnoError(Errno.EINVAL, 'Invalid download type: ' + type));
+		case 'size':
+			throw err(new ErrnoError(Errno.EBADE, error.message));
+		case 'buffer':
+			throw err(new ErrnoError(Errno.EIO, 'Failed to decode buffer'));
 	}
 }
 
@@ -77,7 +64,7 @@ export class FetchTransaction extends Transaction<FetchStore> {
 
 	public async set(id: number, data: Uint8Array, offset?: number): Promise<number> {
 		if (offset) {
-			const buffer = growBuffer((await this.get(id)) ?? new Uint8Array(), data.byteLength + offset);
+			const buffer = extendBuffer((await this.get(id)) ?? new Uint8Array(), data.byteLength + offset);
 			buffer.set(data, offset);
 			data = buffer;
 		}
@@ -88,7 +75,7 @@ export class FetchTransaction extends Transaction<FetchStore> {
 
 	public setSync(id: number, data: Uint8Array, offset?: number): number {
 		if (offset) {
-			const buffer = growBuffer(this.getSync(id) ?? new Uint8Array(), data.byteLength + offset);
+			const buffer = extendBuffer(this.getSync(id) ?? new Uint8Array(), data.byteLength + offset);
 			buffer.set(data, offset);
 			data = buffer;
 		}
@@ -241,7 +228,7 @@ export class FetchFS extends StoreFS<FetchStore> {
 		for (const [path, node] of index) {
 			if (!(node.mode & S_IFREG)) continue;
 
-			const content = await fetchFile(this.baseUrl + path, 'buffer', this.requestInit);
+			const content = await fetchWithRanges(this.baseUrl + path, { warn }, this.requestInit).catch(parseError);
 
 			await tx.set(node.data, content);
 		}
@@ -257,10 +244,14 @@ export class FetchFS extends StoreFS<FetchStore> {
 		log_deprecated('FetchFS');
 		super(
 			new FetchStore(typeof index == 'string' ? new Index() : new Index().fromJSON(index), {
-				get: async (id: number) => {
+				get: async (id: number, start?: number, end?: number) => {
 					const { entries } = await this.indexData;
-					const path = Object.entries(entries).find(([, node]) => node.data == id)?.[0];
-					return fetchFile(this.baseUrl + path, 'buffer', this.requestInit).catch(() => undefined);
+
+					const [path, { size } = {}] = Object.entries(entries).find(([, node]) => node.data == id) || [];
+					if (!path || typeof size != 'number') return;
+					return fetchWithRanges(this.baseUrl + path, { start, end, size, warn }, this.requestInit)
+						.catch(parseError)
+						.catch(() => undefined);
 				},
 				set() {
 					throw ErrnoError.With('ENOTSUP');
@@ -274,7 +265,12 @@ export class FetchFS extends StoreFS<FetchStore> {
 		// prefix url must end in a directory separator.
 		if (baseUrl.at(-1) == '/') this.baseUrl = baseUrl.slice(0, -1);
 
-		this.indexData = typeof index != 'string' ? index : fetchFile<IndexData>(index, 'json', requestInit);
+		this.indexData =
+			typeof index != 'string'
+				? index
+				: fetchWithRanges(index, { warn }, requestInit)
+						.catch(parseError)
+						.then(data => JSON.parse(decodeUTF8(data)));
 	}
 }
 /* node:coverage enable */
@@ -301,8 +297,14 @@ const _Fetch = {
 
 		options.index ??= 'index.json';
 
-		const indexData = typeof options.index != 'string' ? options.index : await fetchFile<IndexData>(options.index, 'json', options.requestInit);
-		const index = new Index().fromJSON(indexData);
+		const index = new Index();
+
+		if (typeof options.index != 'string') {
+			index.fromJSON(options.index);
+		} else {
+			const data = await fetchWithRanges(options.index, { warn }, options.requestInit).catch(parseError);
+			index.fromJSON(JSON.parse(decodeUTF8(data)));
+		}
 
 		const _update = async (method: 'POST' | 'DELETE', id: number, body?: Uint8Array) => {
 			if (!options.remoteWrite) return;
@@ -317,9 +319,12 @@ const _Fetch = {
 		};
 
 		const store = new FetchStore(index, {
-			async get(id: number) {
-				const path = [...index].find(([, node]) => node.data == id)?.[0];
-				return !path ? undefined : fetchFile(baseUrl + path, 'buffer', options.requestInit).catch(() => undefined);
+			async get(id: number, start?: number, end?: number) {
+				const [path, { size } = {}] = [...index].find(([, node]) => node.data == id) || [];
+				if (!path || typeof size != 'number') return;
+				return await fetchWithRanges(baseUrl + path, { start, end, size, warn }, options.requestInit)
+					.catch(parseError)
+					.catch(() => undefined);
 			},
 			set: (id, body) => _update('POST', id, body),
 			delete: id => _update('DELETE', id),
@@ -336,7 +341,7 @@ const _Fetch = {
 		for (const [path, node] of index) {
 			if (!(node.mode & S_IFREG)) continue;
 
-			const content = await fetchFile(baseUrl + path, 'buffer', options.requestInit);
+			const content = await fetchWithRanges(baseUrl + path, { warn }, options.requestInit).catch(parseError);
 
 			await tx.set(node.data, content);
 		}

--- a/src/backends/memory.ts
+++ b/src/backends/memory.ts
@@ -6,6 +6,8 @@ import { MapTransaction, type MapStore } from './store/map.js';
  * A simple in-memory store
  */
 export class InMemoryStore extends Map<number, Uint8Array> implements MapStore {
+	public readonly flags = [] as const;
+
 	public constructor(public name: string = 'tmp') {
 		super();
 	}

--- a/src/backends/overlay.ts
+++ b/src/backends/overlay.ts
@@ -4,11 +4,12 @@ import type { Stats } from '../stats.js';
 import type { Backend } from './backend.js';
 import type { InodeLike } from './store/inode.js';
 
+import { canary } from 'utilium';
 import { Errno, ErrnoError } from '../error.js';
 import { LazyFile, parseFlag } from '../file.js';
 import { FileSystem } from '../filesystem.js';
 import { crit, err } from '../log.js';
-import { canary, decodeUTF8, encodeUTF8 } from '../utils.js';
+import { decodeUTF8, encodeUTF8 } from '../utils.js';
 import { dirname, join } from '../vfs/path.js';
 
 /** @internal */
@@ -444,7 +445,7 @@ export class OverlayFS extends FileSystem {
 		let parent = dirname(path);
 		const toCreate: string[] = [];
 
-		const silence = canary(path);
+		const silence = canary(ErrnoError.With('EDEADLK', path));
 		while (!this.writable.existsSync(parent)) {
 			toCreate.push(parent);
 			parent = dirname(parent);
@@ -465,7 +466,7 @@ export class OverlayFS extends FileSystem {
 		let parent = dirname(path);
 		const toCreate: string[] = [];
 
-		const silence = canary(path);
+		const silence = canary(ErrnoError.With('EDEADLK', path));
 		while (!(await this.writable.exists(parent))) {
 			toCreate.push(parent);
 			parent = dirname(parent);

--- a/src/backends/store/file_index.ts
+++ b/src/backends/store/file_index.ts
@@ -41,6 +41,18 @@ export class Index extends Map<string, Readonly<Inode>> {
 		return JSON.stringify(this.toJSON());
 	}
 
+	public pathOf(id: number): string | undefined {
+		for (const [path, inode] of this) {
+			if (inode.ino == id || inode.data == id) return path;
+		}
+	}
+
+	public getByID(id: number): Readonly<Inode> | undefined {
+		for (const inode of this.values()) {
+			if (inode.ino == id || inode.data == id) return inode;
+		}
+	}
+
 	public directoryEntries(path: string): Record<string, number> {
 		const node = this.get(path);
 

--- a/src/backends/store/map.ts
+++ b/src/backends/store/map.ts
@@ -1,4 +1,4 @@
-import { SyncTransaction, type Store } from './store.js';
+import { SyncTransaction, type Store, type StoreFlag } from './store.js';
 
 /**
  * An interface for simple synchronous stores that don't have special support for transactions and such, based on `Map`
@@ -17,6 +17,8 @@ export interface MapStore extends Store {
  */
 export abstract class AsyncMapStore implements MapStore {
 	public abstract name: string;
+
+	public abstract readonly flags: StoreFlag[];
 
 	protected cache: Map<number, Uint8Array> = new Map();
 
@@ -80,7 +82,7 @@ export abstract class AsyncMapStore implements MapStore {
  * @see AsyncMapStore
  */
 export class MapTransaction extends SyncTransaction<MapStore> {
-	protected declare store: MapStore;
+	public declare readonly store: MapStore;
 
 	public keysSync(): Iterable<number> {
 		return this.store.keys();
@@ -94,8 +96,9 @@ export class MapTransaction extends SyncTransaction<MapStore> {
 		return this.store.get(id);
 	}
 
-	public setSync(id: number, data: Uint8Array): void {
-		return this.store.set(id, data);
+	public setSync(id: number, data: Uint8Array): number {
+		this.store.set(id, data);
+		return data.byteLength;
 	}
 
 	public removeSync(id: number): void {

--- a/src/devices.ts
+++ b/src/devices.ts
@@ -2,6 +2,7 @@
 This is a great resource: https://www.kernel.org/doc/html/latest/admin-guide/devices.html
 */
 
+import { canary } from 'utilium';
 import { Inode } from './backends/index.js';
 import { InMemoryStore } from './backends/memory.js';
 import { StoreFS } from './backends/store/fs.js';
@@ -11,7 +12,7 @@ import { File } from './file.js';
 import type { CreationOptions } from './filesystem.js';
 import { alert, err, log_deprecated } from './log.js';
 import { Stats } from './stats.js';
-import { canary, decodeUTF8 } from './utils.js';
+import { decodeUTF8 } from './utils.js';
 import { S_IFBLK, S_IFCHR } from './vfs/constants.js';
 import { basename, dirname } from './vfs/path.js';
 
@@ -281,7 +282,7 @@ export class DeviceFS extends StoreFS<InMemoryStore> {
 			throw ErrnoError.With('EEXIST', path, 'mknod');
 		}
 		let ino = 1;
-		const silence = canary(path, 'mknod');
+		const silence = canary(ErrnoError.With('EDEADLK', path, 'mknod'));
 		while (this.store.has(ino)) ino++;
 		silence();
 		const dev = {

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,7 +3,7 @@ import type { FileSystem } from './filesystem.js';
 import { log_deprecated } from './log.js';
 import './polyfills.js';
 import { _chown, Stats, type StatsLike } from './stats.js';
-import { growBuffer } from './utils.js';
+import { extendBuffer } from 'utilium/buffer.js';
 import { config } from './vfs/config.js';
 import * as c from './vfs/constants.js';
 
@@ -408,7 +408,7 @@ export class PreloadFile<FS extends FileSystem> extends File<FS> {
 		const end = position + length;
 		const slice = buffer.subarray(offset, offset + length);
 
-		this._buffer = growBuffer(this._buffer, end);
+		this._buffer = extendBuffer(this._buffer, end);
 		if (end > this.stats.size) this.stats.size = end;
 
 		this._buffer.set(slice, position);


### PR DESCRIPTION
This is a PR to track the progression of #53.

The implementation in https://github.com/zen-fs/core/commit/50e600d6eea9c523fd18155e35a286e7c0e86a11 involves some changes to transactions that are not backwards type compatible and not runtime forward compatible. Due to the significance of these changes, I've labeled the PR as breaking.

Tests have not been changed at all and are passing, so that is good at least.