### PR TITLE
`SingleBuffer`: Add missing offset to `MetadataBlock` constuctor

### DIFF
--- a/src/backends/single_buffer.ts
+++ b/src/backends/single_buffer.ts
@@ -85,6 +85,8 @@ class SuperBlock {
 		if (store._view.getUint32(offsetof(SuperBlock, 'magic'), true) != sb_magic) {
 			warn('SingleBuffer: Invalid magic value, assuming this is a fresh super block');
 			this.metadata = new MetadataBlock(this);
+			this.metadata.offset = sizeof(SuperBlock);
+			this.metadata_offset = this.metadata.offset;
 			this.used_bytes = BigInt(sizeof(SuperBlock) + sizeof(MetadataBlock));
 			this.total_bytes = BigInt(store._buffer.byteLength);
 			store._write(this);

--- a/tests/backend/single-buffer.test.ts
+++ b/tests/backend/single-buffer.test.ts
@@ -1,0 +1,24 @@
+import test, { suite } from 'node:test';
+import { fs as _fs, mount, resolveMountConfig, SingleBuffer, umount } from '../../dist/index.js';
+import assert from 'node:assert';
+
+await suite('SingleBuffer`', () => {
+	test('should be able to restore filesystem (with same metadata) from original buffer', async () => {
+		const buffer = new ArrayBuffer(0x100000);
+
+		umount('/');
+		const writable = await resolveMountConfig({ backend: SingleBuffer, buffer });
+		mount('/', writable);
+
+		_fs.writeFileSync('/example.ts', 'console.log("hello world")', 'utf-8');
+		const stats = _fs.statSync('/example.ts');
+
+		umount('/');
+		const snapshot = await resolveMountConfig({ backend: SingleBuffer, buffer });
+		mount('/', snapshot);
+
+		const snapshotStats = _fs.statSync('/example.ts');
+
+		assert.deepEqual(snapshotStats, stats);
+	});
+});


### PR DESCRIPTION
* Addresses https://github.com/zen-fs/core/issues/204
* Also includes a test to ensure SingleBuffer works as expected