### PR TITLE
Implement test for `SingleBuffer` with `SharedArrayBuffer` in Node environment

### DIFF
--- a/tests/backend/single-buffer.test.ts
+++ b/tests/backend/single-buffer.test.ts
@@ -1,6 +1,7 @@
 import { test, suite } from 'node:test';
 import { fs, mount, resolveMountConfig, SingleBuffer, umount } from '../../dist/index.js';
 import assert from 'node:assert';
+import { Worker } from 'worker_threads';
 
 await suite('SingleBuffer', () => {
 	test('should be able to restore filesystem (with same metadata) from original buffer', async () => {
@@ -20,5 +21,28 @@ await suite('SingleBuffer', () => {
 		const snapshotStats = fs.statSync('/example.ts');
 
 		assert.deepEqual(snapshotStats, stats);
+	});
+
+	test('should support SharedArrayBuffer across threads', async () => {
+		const sharedBuffer = new SharedArrayBuffer(0x100000);
+
+		umount('/');
+		const writable = await resolveMountConfig({ backend: SingleBuffer, buffer: sharedBuffer });
+		mount('/', writable);
+
+		const worker = new Worker(import.meta.dirname + '/single-buffer.worker.js', { workerData: sharedBuffer });
+
+		// Pause while we wait for the worker to emit the 'continue' message, which
+		// means it has mounted the filesystem and created /worker-file.ts
+		await new Promise<void>(resolve => {
+			worker.on('message', message => {
+				if (message === 'continue') resolve();
+			});
+		});
+
+		worker.terminate();
+		worker.unref();
+
+		assert(fs.existsSync('/worker-file.ts'));
 	});
 });

--- a/tests/backend/single-buffer.worker.js
+++ b/tests/backend/single-buffer.worker.js
@@ -1,0 +1,15 @@
+import { parentPort, workerData } from 'node:worker_threads';
+import { configure, SingleBuffer, fs } from '../../dist/index.js';
+
+await configure({
+	mounts: {
+		'/': {
+			backend: SingleBuffer,
+			buffer: workerData,
+		},
+	},
+});
+
+fs.writeFileSync('/worker-file.ts', 'console.log("this file was created by the worker")', 'utf-8');
+
+parentPort.postMessage('continue');


### PR DESCRIPTION
Discussed in #210 

Adds a failing test for `SingleBuffer` using a `SharedArrayBuffer` in the Node environment.