### PR TITLE
Fix crypto.randomUUID is not available in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
 		"kerium": "^1.3.4",
 		"memium": "^0.2.0",
 		"readable-stream": "^4.5.2",
-		"utilium": "^2.3.3"
+		"utilium": "^2.3.3",
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.8.0",

--- a/src/backends/single_buffer.ts
+++ b/src/backends/single_buffer.ts
@@ -11,6 +11,7 @@ import type { Backend } from './backend.js';
 import { StoreFS } from './store/fs.js';
 import { SyncMapTransaction, type SyncMapStore } from './store/map.js';
 import type { Store } from './store/store.js';
+import { v4 as uuidv4 } from 'uuid';
 
 type Lock = Disposable & (() => void);
 
@@ -174,7 +175,7 @@ export class SuperBlock extends BufferView {
 				version: 1,
 				inode_format: _inode_version,
 				metadata_block_size: sizeof(MetadataBlock),
-				uuid: encodeUUID(crypto.randomUUID()),
+				uuid: encodeUUID(uuidv4() as UUID),
 			});
 			_update(this);
 			_update(md);

--- a/src/internal/filesystem.ts
+++ b/src/internal/filesystem.ts
@@ -1,6 +1,7 @@
 import type { UUID } from 'node:crypto';
 import type { ConstMap } from 'utilium';
 import type { InodeLike } from './inode.js';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Usage information about a file system
@@ -160,7 +161,7 @@ export abstract class FileSystem {
 	 * @privateRemarks This is only used by `ioctl`
 	 * @internal @protected
 	 */
-	_uuid: UUID = crypto.randomUUID();
+	_uuid: UUID = uuidv4() as UUID;
 
 	public get uuid(): UUID {
 		return this._uuid;


### PR DESCRIPTION
Crypto package not available in browser environment, so we add uuid package to make core portable