### PR TITLE
Attempt to create a test

### DIFF
--- a/tests/backend/single-buffer.test.ts
+++ b/tests/backend/single-buffer.test.ts
@@ -82,5 +82,5 @@ await suite('SingleBuffer', () => {
 				assert.strictEqual(srcContent, dstContent);
 			}
 		}
-	})
+	});
 });


### PR DESCRIPTION
As requested, currently failing:

```sh
theodores-MacBook-Pro:zenfs-core theodorebrockman$ npx tsx tests/backend/single-buffer.test.ts 
▶ SingleBuffer
  ✔ filesystem restoration from original buffer (with same metadata) (10.657334ms)
  ✔ cross-thread SharedArrayBuffer (99.360167ms)
  ✖ should recursively copy files with with same stats (28.865125ms)
✖ SingleBuffer (139.574667ms)
ℹ tests 3
ℹ suites 1
ℹ pass 2
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1017.996416

✖ failing tests:

test at tests/backend/single-buffer.test.ts:1:1499
✖ should recursively copy files with with same stats (28.865125ms)
  Exception [Error]: EISDIR: File is a directory, open '/dst'
      at Module._openSync (file:///Users/theodorebrockman/Documents/dev/zenfs-core/dist/vfs/sync.js:227:15)
      at Module.openSync (file:///Users/theodorebrockman/Documents/dev/zenfs-core/dist/vfs/sync.js:238:27)
      at Module.utimesSync (file:///Users/theodorebrockman/Documents/dev/zenfs-core/dist/vfs/sync.js:623:25)
      at Module.cpSync (file:///Users/theodorebrockman/Documents/dev/zenfs-core/dist/vfs/sync.js:850:20)
      at TestContext.<anonymous> (/Users/theodorebrockman/Documents/dev/zenfs-core/tests/backend/single-buffer.test.ts:66:6)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async Test.run (node:internal/test_runner/test:1054:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:744:7) {
    errno: 21,
    code: 'EISDIR',
    path: '/dst',
    dest: undefined,
    syscall: 'open'
  }
  ```