### PR TITLE
fix: root dir will erasured when disableAsyncCache set

### DIFF
--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -91,9 +91,9 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 		if (this._initialized) return;
 
 		if (!this.attributes.has('no_async_preload')) {
-		  this.checkRootSync();	
+			this.checkRootSync();
 		}
-		
+
 		await this.checkRoot();
 		await this._populate();
 		this._initialized = true;

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -90,7 +90,10 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 	public async ready(): Promise<void> {
 		if (this._initialized) return;
 
-		this.checkRootSync();
+		if (!this.attributes.has('no_async_preload')) {
+		  this.checkRootSync();	
+		}
+		
 		await this.checkRoot();
 		await this._populate();
 		this._initialized = true;


### PR DESCRIPTION
```typescript
import { IndexedDB } from '@zenfs/dom';
import { resolveMountConfig, fs } from '@zenfs/core';

const mountConfig = await resolveMountConfig({
    backend: IndexedDB,
    storeName: dbStoreName,
    disableAsyncCache: true,
});
fs.mount(rootDir, mountConfig);
```

when set `disableAsyncCache: true`

`await fs.readdir(rootDir)` always empty