### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,173 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758463745,
+        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "libSource": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "libSource_2": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761597516,
+        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
+        "libSource": "libSource",
+        "nixpkgs": "nixpkgs",
+        "xome": "xome"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "xome": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "home-manager": [
+          "home-manager"
+        ],
+        "libSource": "libSource_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761846841,
+        "narHash": "sha256-5bflKPoF32mQjyZGmOKG5ZFgelaVPlbEDP4izo0OcVY=",
+        "owner": "jeff-hykin",
+        "repo": "xome",
+        "rev": "f3678114105e56e3e602355e76a38f09a2704f11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeff-hykin",
+        "repo": "xome",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,212 @@
+{
+    description = "ZenFS";
+    inputs = {
+        libSource.url = "github:divnix/nixpkgs.lib";
+        flake-utils.url = "github:numtide/flake-utils";
+        nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+        home-manager.url = "github:nix-community/home-manager/release-25.05";
+        home-manager.inputs.nixpkgs.follows = "nixpkgs";
+        xome.url = "github:jeff-hykin/xome";
+        xome.inputs.nixpkgs.follows = "nixpkgs";
+        xome.inputs.home-manager.follows = "home-manager";
+    };
+    outputs = { self, flake-utils, nixpkgs, xome, ... }:
+        flake-utils.lib.eachSystem flake-utils.lib.defaultSystems (system:
+            let
+                projectName = "zen-fs_core"; # used as directory name (e.g. no slashes)
+                pkgs = import nixpkgs {
+                    inherit system;
+                    overlays = [
+                    ];
+                    config = {
+                        allowUnfree = true;
+                        allowInsecure = false;
+                        permittedInsecurePackages = [];
+                    };
+                };
+                inputPackages = [
+                    pkgs.nodejs
+                    pkgs.cacert # needed for installing npm packages
+                    pkgs.corepack
+                    pkgs.yarn
+                    pkgs.esbuild
+                    pkgs.graphviz # used for visualizing circular dependencies (e.g. debugging only)
+                    pkgs.nodePackages.typescript
+                    pkgs.nodePackages.prettier
+                ];
+            in
+                {
+                    # development environment for contributions
+                    devShells = xome.simpleMakeHomeFor {
+                        inherit pkgs;
+                        pure = true;
+                        homeModule = {
+                            # for home-manager examples, see: 
+                            # https://deepwiki.com/nix-community/home-manager/5-configuration-examples
+                            # all home-manager options: 
+                            # https://nix-community.github.io/home-manager/options.xhtml
+                            home.homeDirectory = "/tmp/virtual_homes/${projectName}";
+                            home.stateVersion = "25.05";
+                            home.packages = inputPackages ++ [
+                                # vital stuff
+                                pkgs.dash # provides "sh" 
+                                pkgs.coreutils-full
+                                
+                                # optional stuff
+                                pkgs.gnugrep
+                                pkgs.findutils
+                                pkgs.wget
+                                pkgs.curl
+                                pkgs.unixtools.locale
+                                pkgs.unixtools.more
+                                pkgs.unixtools.ps
+                                pkgs.unixtools.getopt
+                                pkgs.unixtools.ifconfig
+                                pkgs.unixtools.hostname
+                                pkgs.unixtools.ping
+                                pkgs.unixtools.hexdump
+                                pkgs.unixtools.killall
+                                pkgs.unixtools.mount
+                                pkgs.unixtools.sysctl
+                                pkgs.unixtools.top
+                                pkgs.unixtools.umount
+                                pkgs.git
+                                pkgs.htop
+                                pkgs.ripgrep
+                            ];
+                            
+                            programs = {
+                                home-manager = {
+                                    enable = true;
+                                };
+                                zsh = {
+                                    enable = true;
+                                    enableCompletion = true;
+                                    autosuggestion.enable = true;
+                                    syntaxHighlighting.enable = true;
+                                    shellAliases.ll = "ls -la";
+                                    history.size = 100000;
+                                    # this is kinda like .zshrc
+                                    initContent = ''
+                                        # lots of things need "sh"
+                                        ln -s "$(which dash)" "$HOME/.local/bin/sh" 2>/dev/null
+                                        
+                                        # without this npm (from nix) will not keep a reliable cache (it'll be outside of the xome home)
+                                        if ! [ -d "node_modules" ]
+                                        then
+                                            printf "\n\nI don't see node modules, want me to install them (default=yes)? [y/n]\n";answer=""
+                                            while true; do
+                                                echo "$question"; read response
+                                                case "$response" in
+                                                    [Yy]* ) answer='yes'; break;;
+                                                    [Nn]* ) answer='no'; break;;
+                                                    * ) echo "Please answer yes or no.";;
+                                                esac
+                                            done
+                                            
+                                            if [ "$answer" = 'yes' ]; then
+                                                yarn install
+                                            else
+                                                echo "skipping"
+                                            fi
+                                        fi
+                                        export npm_config_cache="$HOME/.cache/npm"
+                                        
+                                        # this enables some impure stuff like sudo, comment it out to get FULL purity
+                                        # export PATH="$PATH:/usr/bin/"
+                                        echo
+                                        echo "NOTE: if you want to use sudo/git/vim/etc (anything impure) do: sys <that command>"
+                                    '';
+                                };
+                                starship = {
+                                    enable = true;
+                                    enableZshIntegration = true;
+                                    settings = {
+                                        character = {
+                                            success_symbol = "[∫](bold green)";
+                                            error_symbol = "[∫](bold red)";
+                                        };
+                                    };
+                                };
+                            };
+                        }; 
+                    };
+                    
+                    # as an automated reproducible dependency
+                    packages.default = (
+                        let
+                            # The path to the npm project
+                            src = ./.;
+
+                            # Read the package-lock.json as a Nix attrset
+                            packageLock = builtins.fromJSON (builtins.readFile (src + "/package-lock.json"));
+
+                            # Create an array of all (meaningful) dependencies
+                            deps = builtins.attrValues (removeAttrs packageLock.packages [ "" ])
+                                ++ (
+                                    if (builtins.hasAttr "dependencies" packageLock) then
+                                        builtins.attrValues (removeAttrs packageLock.dependencies [ "" ])
+                                    else
+                                        []
+                                )
+                            ;
+
+                            # Turn each dependency into a fetchurl call
+                            tarballs = map (p: pkgs.fetchurl { url = p.resolved; hash = p.integrity; }) deps;
+
+                            # Write a file with the list of tarballs
+                            tarballsFile = pkgs.writeTextFile {
+                                name = "tarballs";
+                                text = builtins.concatStringsSep "\n" tarballs;
+                            };
+                        in
+                            pkgs.stdenv.mkDerivation {
+                                inherit (packageLock) name version;
+                                inherit src;
+                                buildInputs = inputPackages; # needed for https
+                                
+                                buildPhase = ''
+                                    # ensure TMPDIR is defined, fallback to /tmp
+                                    : ${TMPDIR:=/tmp}
+                                    echo "Using TMPDIR=$TMPDIR"
+
+                                    # define writable npm locations
+                                    export HOME="$PWD/.home"
+                                    export NPM_CONFIG_CACHE="$HOME/.cache/npm"
+                                    export npm_config_cache="$NPM_CONFIG_CACHE"
+                                    export NPM_CONFIG_TMP="$HOME/.npm-tmp"
+                                    export NPM_CONFIG_PREFIX="$out"
+
+                                    # ensure dirs exist and are writable
+                                    mkdir -p "$NPM_CONFIG_CACHE" "$NPM_CONFIG_TMP" "$NPM_CONFIG_PREFIX"
+                                    
+                                    js_path="$out/src"
+                                    mkdir -p "$js_path"
+                                    cp -r "$src/." "$js_path"
+                                    # make locks writable
+                                    chmod +w "$js_path/yarn.lock" 2>/dev/null || true
+                                    chmod +w "$js_path/package-lock.json" 2>/dev/null || true
+
+                                    cd "$js_path"
+                                    while read package
+                                    do
+                                        echo "caching $package"
+                                        npm cache add "$package"
+                                    done <${tarballsFile}
+                                    
+                                    npm ci --no-save --no-audit --no-fund
+                                    echo "npm run build"
+                                    npm run build
+                                '';
+
+                                installPhase = ''
+                                    # uncomment below if the project creates binaries to share
+                                    # ln -s "$js_path/node_modules/.bin" "$out/bin"
+                                    mkdir -p "$out/dist"
+                                    cp -r dist/* "$out/dist"
+                                '';
+                            }
+                    );
+                }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,6 @@
                 inputPackages = [
                     pkgs.nodejs
                     pkgs.cacert # needed for installing npm packages
-                    pkgs.corepack
-                    pkgs.yarn
-                    pkgs.esbuild
-                    pkgs.graphviz # used for visualizing circular dependencies (e.g. debugging only)
                     pkgs.nodePackages.typescript
                     pkgs.nodePackages.prettier
                 ];
@@ -107,7 +103,7 @@
                                             done
                                             
                                             if [ "$answer" = 'yes' ]; then
-                                                yarn install
+                                                npm install
                                             else
                                                 echo "skipping"
                                             fi

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,8 @@
                                         ln -s "$(which dash)" "$HOME/.local/bin/sh" 2>/dev/null
                                         
                                         # without this npm (from nix) will not keep a reliable cache (it'll be outside of the xome home)
+                                        export npm_config_cache="$HOME/.cache/npm"
+                                        
                                         if ! [ -d "node_modules" ]
                                         then
                                             printf "\n\nI don't see node modules, want me to install them (default=yes)? [y/n]\n";answer=""
@@ -110,10 +112,7 @@
                                                 echo "skipping"
                                             fi
                                         fi
-                                        export npm_config_cache="$HOME/.cache/npm"
                                         
-                                        # this enables some impure stuff like sudo, comment it out to get FULL purity
-                                        # export PATH="$PATH:/usr/bin/"
                                         echo
                                         echo "NOTE: if you want to use sudo/git/vim/etc (anything impure) do: sys <that command>"
                                     '';


### PR DESCRIPTION
1. This code doesn't really ever need to be updated (it pulls from the package.json / package-lock.json)
2. It enables two helpful things:
    1. `nix develop` drops user's into a shell where everything is installed with exact versions, kind of like docker but without the overhead of a VM
    2. `nix build .` is a sandboxed reproducable build. E.g. it prevents "well it works on my machine" kind of bugs

This should make for an extremely fast and reliable ZenFS setup from zero:
- Install nix: `curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install`
- Clone the repo: `nix run 'nixpkgs#git' clone 'git@github.com:zen-fs/core.git'`
- Enter the dev shell: `cd core;nix develop`
- Run tests: `npm run build; npm run test`

The only maintaince is, run `nix flake update` when you want to update the version of node.js that it defaults to.