### PR TITLE
Fixed  '/' not being included in emitChange parent walk

### DIFF
--- a/src/vfs/watchers.ts
+++ b/src/vfs/watchers.ts
@@ -196,14 +196,17 @@ export function emitChange(context: V_Context, eventType: fs.WatchEventType, fil
 	if ($) filename = join($.root ?? '/', filename);
 	filename = normalizePath(filename);
 
-	// Notify watchers, including ones on parent directories if they are watching recursively
-	for (let path = filename; path != '/'; path = dirname(path)) {
+	// Notify watchers, including ones on parent directories if they are watching recursively.
+	// The walk includes '/' so a watcher on the root also fires (previously `path != '/'` skipped it).
+	for (let path = filename; ; path = dirname(path)) {
 		const watchersForPath = watchers.get(path);
 
-		if (!watchersForPath) continue;
-
-		for (const watcher of watchersForPath) {
-			watcher.emit('change', eventType, relative.call(watcher._context, path, filename) || basename(filename));
+		if (watchersForPath) {
+			for (const watcher of watchersForPath) {
+				watcher.emit('change', eventType, relative.call(watcher._context, path, filename) || basename(filename));
+			}
 		}
+
+		if (path === '/') break;
 	}
 }

--- a/tests/fs/watch.test.ts
+++ b/tests/fs/watch.test.ts
@@ -156,4 +156,23 @@ suite('Watch', () => {
 		await watcher.return!();
 		await promise;
 	});
+
+	test('watch("/") receives events for files under root', async () => {
+		// Regression: emitChange previously exited its parent-walk before
+		// checking watchers.get('/'), so a watcher registered on '/' never fired.
+		const { promise, resolve } = Promise.withResolvers<[string, string]>();
+
+		using watcher = fs.watch('/', (eventType, filename) => {
+			resolve([eventType, filename]);
+		});
+
+		await fs.promises.writeFile('/watch-root-file.txt', 'x');
+
+		const [eventType, filename] = await Promise.race([
+			promise,
+			new Promise<[string, string]>((_, reject) => setTimeout(() => reject(new Error('watch("/") timed out')), 1000)),
+		]);
+		assert.equal(eventType, 'change');
+		assert.equal(filename, 'watch-root-file.txt');
+	});
 });


### PR DESCRIPTION
Fix watchers on '/' the root path.