### PR TITLE
Replaced Iterator helpers with spread (#296, thanks @jcubic)

### DIFF
--- a/src/backends/cow.ts
+++ b/src/backends/cow.ts
@@ -40,7 +40,7 @@ function isJournalOp(op: string): op is JournalOperation {
 	return journalOperations.has(op);
 }
 
-const maxOpLength = Math.max(...journalOperations.values().map(op => op.length));
+const maxOpLength = Math.max(...[...journalOperations.values()].map(op => op.length));
 
 /**
  * @category Internals

--- a/src/backends/cow.ts
+++ b/src/backends/cow.ts
@@ -40,7 +40,7 @@ function isJournalOp(op: string): op is JournalOperation {
 	return journalOperations.has(op);
 }
 
-const maxOpLength = Math.max(...[...journalOperations.values()].map(op => op.length));
+const maxOpLength = Math.max(...[...journalOperations].map(op => op.length));
 
 /**
  * @category Internals

--- a/src/vfs/xattr.ts
+++ b/src/vfs/xattr.ts
@@ -281,7 +281,7 @@ export async function list(this: V_Context, path: string): Promise<Name[]> {
 
 	if (!inode.attributes) return [];
 
-	return inode.attributes.keys().toArray() as Name[];
+	return [...inode.attributes.keys()] as Name[];
 }
 
 /**
@@ -303,5 +303,5 @@ export function listSync(this: V_Context, path: string): Name[] {
 
 	if (!inode.attributes) return [];
 
-	return inode.attributes.keys().toArray() as Name[];
+	return [...inode.attributes.keys()] as Name[];
 }


### PR DESCRIPTION
This PR adds compatibility to older browsers.

PS: I'm working on adding back Matrix Karma tests in isomorphic git that were removed during migration to ZenFS. This is needed to test on older browsers that don't implement ES2025.