### PR TITLE
Fix SingleBuffer metadata alignment during concurrent writes

### DIFF
--- a/src/backends/single_buffer.ts
+++ b/src/backends/single_buffer.ts
@@ -267,12 +267,23 @@ export class SuperBlock extends $from.typed(BigUint64Array)<ArrayBufferLike> {
 	 * @returns the new metadata block
 	 */
 	public rotateMetadata(): MetadataBlock {
-		const padding = this.used_bytes % BigInt(4);
+		const alignment = BigInt(Int32Array.BYTES_PER_ELEMENT);
+		const blockSize = BigInt(sizeof(MetadataBlock));
+		let used = Atomics.load(this, usedBytes);
+		let offset: bigint;
 
-		Atomics.add(this, usedBytes, padding);
-		const offset = Number(Atomics.add(this, usedBytes, BigInt(sizeof(MetadataBlock))));
+		// Padding and block space must be reserved together because other writers
+		// can advance used_bytes at any time.
+		for (;;) {
+			const padding = (alignment - (used % alignment)) % alignment;
+			offset = used + padding;
+			const next = offset + blockSize;
+			const observed = Atomics.compareExchange(this, usedBytes, used, next);
+			if (observed === used) break;
+			used = observed;
+		}
 
-		const metadata = new MetadataBlock(this.buffer, offset);
+		const metadata = new MetadataBlock(this.buffer, Number(offset));
 		metadata.previous_offset = this.metadata_offset;
 
 		this.metadata = metadata;
@@ -280,7 +291,7 @@ export class SuperBlock extends $from.typed(BigUint64Array)<ArrayBufferLike> {
 		_update(metadata);
 		_update(this);
 
-		debug(`sbfs: rotated metadata block at ${hex(metadata.previous_offset)} with new block at ${hex(offset)}`);
+		debug(`sbfs: rotated metadata block at ${hex(metadata.previous_offset)} with new block at ${hex(metadata.byteOffset)}`);
 
 		return metadata;
 	}

--- a/src/backends/single_buffer.ts
+++ b/src/backends/single_buffer.ts
@@ -267,13 +267,12 @@ export class SuperBlock extends $from.typed(BigUint64Array)<ArrayBufferLike> {
 	 * @returns the new metadata block
 	 */
 	public rotateMetadata(): MetadataBlock {
-		const alignment = BigInt(Int32Array.BYTES_PER_ELEMENT);
-		const blockSize = BigInt(sizeof(MetadataBlock));
-		let used = Atomics.load(this, usedBytes);
-		let offset: bigint;
+		const alignment = BigInt(Int32Array.BYTES_PER_ELEMENT),
+			blockSize = BigInt(sizeof(MetadataBlock));
+		let used = Atomics.load(this, usedBytes),
+			offset: bigint;
 
-		// Padding and block space must be reserved together because other writers
-		// can advance used_bytes at any time.
+		// Padding and block space must be reserved together because other writers can advance used_bytes at any time.
 		for (;;) {
 			const padding = (alignment - (used % alignment)) % alignment;
 			offset = used + padding;

--- a/tests/backend/single-buffer.test.ts
+++ b/tests/backend/single-buffer.test.ts
@@ -54,7 +54,7 @@ await suite('SingleBuffer', () => {
 		assert(fs.existsSync('/shared/worker-file.ts'));
 	});
 
-	test('aligns metadata after another thread reserves space', async () => {
+	test('aligns metadata after another thread reserves space #309', async () => {
 		const buffer = new SharedArrayBuffer(0x100000);
 		const gate = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 		const superblock = new SuperBlock(buffer);
@@ -159,7 +159,7 @@ await suite('SingleBuffer', () => {
 		}
 	});
 
-	test('keeps metadata aligned when files have uneven sizes', async () => {
+	test('keeps metadata aligned when files have uneven sizes #309', async () => {
 		const mountPoint = '/sbfs-rotation';
 		const buffer = new ArrayBuffer(0x400000);
 		const writable = await resolveMountConfig({ backend: SingleBuffer, buffer, label: 'rotation' });

--- a/tests/backend/single-buffer.test.ts
+++ b/tests/backend/single-buffer.test.ts
@@ -3,8 +3,9 @@ import assert from 'node:assert';
 import { randomBytes } from 'node:crypto';
 import { suite, test } from 'node:test';
 import { Worker } from 'worker_threads';
+import { sizeof } from 'memium';
 import { fs, mount, resolveMountConfig, SingleBuffer, vfs } from '@zenfs/core';
-import { SuperBlock } from '@zenfs/core/backends/single_buffer.js';
+import { MetadataBlock, SuperBlock } from '@zenfs/core/backends/single_buffer.js';
 import { setupLogs } from '../logs.js';
 
 setupLogs();
@@ -54,62 +55,17 @@ await suite('SingleBuffer', () => {
 		assert(fs.existsSync('/shared/worker-file.ts'));
 	});
 
-	test('aligns metadata after another thread reserves space #309', async () => {
-		const buffer = new SharedArrayBuffer(0x100000);
-		const gate = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
-		const superblock = new SuperBlock(buffer);
-		const usedBytes = 2;
-		superblock.used_bytes = 8193n;
-
-		const worker = new Worker(
-			`const { parentPort, workerData } = require('node:worker_threads');
-			const superblock = new BigUint64Array(workerData.buffer);
-			parentPort.postMessage('ready');
-			Atomics.wait(workerData.gate, 0, 0);
-			Atomics.add(superblock, workerData.usedBytes, 5n);
-			Atomics.store(workerData.gate, 0, 2);
-			Atomics.notify(workerData.gate, 0);`,
-			{ eval: true, workerData: { buffer, gate, usedBytes } }
-		);
-		const add = Atomics.add;
-		const compareExchange = Atomics.compareExchange;
-		let injected = false;
-
-		// Let the worker claim space just before this thread updates used_bytes.
-		const injectConcurrentAllocation = (view: BigUint64Array, index: number) => {
-			if (injected || view !== superblock || index !== usedBytes) return;
-			injected = true;
-			Atomics.store(gate, 0, 1);
-			Atomics.notify(gate, 0);
-			const wait = Atomics.wait(gate, 0, 1, 1000);
-			assert.notStrictEqual(wait, 'timed-out', 'worker did not reserve data in time');
-			assert.strictEqual(Atomics.load(gate, 0), 2);
-		};
-
-		try {
-			await new Promise<void>((resolve, reject) => {
-				worker.once('message', message => (message === 'ready' ? resolve() : reject(new Error(`Unexpected worker message: ${message}`))));
-				worker.once('error', reject);
-			});
-
-			Atomics.add = ((view: BigUint64Array, index: number, value: bigint) => {
-				injectConcurrentAllocation(view, index);
-				return add(view, index, value);
-			}) as typeof Atomics.add;
-			Atomics.compareExchange = ((view: BigUint64Array, index: number, expected: bigint, replacement: bigint) => {
-				injectConcurrentAllocation(view, index);
-				return compareExchange(view, index, expected, replacement);
-			}) as typeof Atomics.compareExchange;
+	test('aligns metadata when used_bytes is unaligned #309', () => {
+		// Writers reserve data of any length, so used_bytes can sit at any remainder when the metadata block is rotated.
+		for (const used of [8192n, 8193n, 8194n, 8195n]) {
+			const superblock = new SuperBlock(new ArrayBuffer(0x100000));
+			superblock.used_bytes = used;
 
 			const metadata = superblock.rotateMetadata();
-			assert.strictEqual(metadata.byteOffset, 8200);
-			assert.strictEqual(metadata.byteOffset % Int32Array.BYTES_PER_ELEMENT, 0);
-			assert(injected, 'test did not inject a concurrent allocation');
-		} finally {
-			Atomics.add = add;
-			Atomics.compareExchange = compareExchange;
-			await worker.terminate();
-			worker.unref();
+			const expected = Number((used + 3n) & ~3n);
+
+			assert.strictEqual(metadata.byteOffset, expected, `metadata offset for used_bytes ${used}`);
+			assert.strictEqual(superblock.used_bytes, BigInt(expected + sizeof(MetadataBlock)), `used_bytes after rotating from ${used}`);
 		}
 	});
 
@@ -165,8 +121,7 @@ await suite('SingleBuffer', () => {
 		const writable = await resolveMountConfig({ backend: SingleBuffer, buffer, label: 'rotation' });
 		mount(mountPoint, writable);
 
-		// Uneven writes leave used_bytes between alignment boundaries when the
-		// metadata block fills up.
+		// Uneven writes leave used_bytes between alignment boundaries when the metadata block fills up.
 		const sizes = [1, 17, 257, 3, 5, 13, 1023, 4095, 7, 9];
 		try {
 			for (let i = 0; i < 400; i++) {

--- a/tests/backend/single-buffer.test.ts
+++ b/tests/backend/single-buffer.test.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { suite, test } from 'node:test';
 import { Worker } from 'worker_threads';
 import { fs, mount, resolveMountConfig, SingleBuffer, vfs } from '@zenfs/core';
+import { SuperBlock } from '@zenfs/core/backends/single_buffer.js';
 import { setupLogs } from '../logs.js';
 
 setupLogs();
@@ -53,6 +54,65 @@ await suite('SingleBuffer', () => {
 		assert(fs.existsSync('/shared/worker-file.ts'));
 	});
 
+	test('aligns metadata after another thread reserves space', async () => {
+		const buffer = new SharedArrayBuffer(0x100000);
+		const gate = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+		const superblock = new SuperBlock(buffer);
+		const usedBytes = 2;
+		superblock.used_bytes = 8193n;
+
+		const worker = new Worker(
+			`const { parentPort, workerData } = require('node:worker_threads');
+			const superblock = new BigUint64Array(workerData.buffer);
+			parentPort.postMessage('ready');
+			Atomics.wait(workerData.gate, 0, 0);
+			Atomics.add(superblock, workerData.usedBytes, 5n);
+			Atomics.store(workerData.gate, 0, 2);
+			Atomics.notify(workerData.gate, 0);`,
+			{ eval: true, workerData: { buffer, gate, usedBytes } }
+		);
+		const add = Atomics.add;
+		const compareExchange = Atomics.compareExchange;
+		let injected = false;
+
+		// Let the worker claim space just before this thread updates used_bytes.
+		const injectConcurrentAllocation = (view: BigUint64Array, index: number) => {
+			if (injected || view !== superblock || index !== usedBytes) return;
+			injected = true;
+			Atomics.store(gate, 0, 1);
+			Atomics.notify(gate, 0);
+			const wait = Atomics.wait(gate, 0, 1, 1000);
+			assert.notStrictEqual(wait, 'timed-out', 'worker did not reserve data in time');
+			assert.strictEqual(Atomics.load(gate, 0), 2);
+		};
+
+		try {
+			await new Promise<void>((resolve, reject) => {
+				worker.once('message', message => (message === 'ready' ? resolve() : reject(new Error(`Unexpected worker message: ${message}`))));
+				worker.once('error', reject);
+			});
+
+			Atomics.add = ((view: BigUint64Array, index: number, value: bigint) => {
+				injectConcurrentAllocation(view, index);
+				return add(view, index, value);
+			}) as typeof Atomics.add;
+			Atomics.compareExchange = ((view: BigUint64Array, index: number, expected: bigint, replacement: bigint) => {
+				injectConcurrentAllocation(view, index);
+				return compareExchange(view, index, expected, replacement);
+			}) as typeof Atomics.compareExchange;
+
+			const metadata = superblock.rotateMetadata();
+			assert.strictEqual(metadata.byteOffset, 8200);
+			assert.strictEqual(metadata.byteOffset % Int32Array.BYTES_PER_ELEMENT, 0);
+			assert(injected, 'test did not inject a concurrent allocation');
+		} finally {
+			Atomics.add = add;
+			Atomics.compareExchange = compareExchange;
+			await worker.terminate();
+			worker.unref();
+		}
+	});
+
 	test('reliability across varied file sizes', async () => {
 		const mountPoint = '/sbfs-reliability';
 		const verifyMountPoint = '/sbfs-verify';
@@ -95,6 +155,29 @@ await suite('SingleBuffer', () => {
 			}
 		} finally {
 			if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+			vfs.umount(mountPoint);
+		}
+	});
+
+	test('keeps metadata aligned when files have uneven sizes', async () => {
+		const mountPoint = '/sbfs-rotation';
+		const buffer = new ArrayBuffer(0x400000);
+		const writable = await resolveMountConfig({ backend: SingleBuffer, buffer, label: 'rotation' });
+		mount(mountPoint, writable);
+
+		// Uneven writes leave used_bytes between alignment boundaries when the
+		// metadata block fills up.
+		const sizes = [1, 17, 257, 3, 5, 13, 1023, 4095, 7, 9];
+		try {
+			for (let i = 0; i < 400; i++) {
+				const content = Buffer.alloc(sizes[i % sizes.length], i & 0xff);
+				fs.writeFileSync(`${mountPoint}/f${i}.txt`, content);
+			}
+			for (let i = 0; i < 400; i += 37) {
+				const expected = Buffer.alloc(sizes[i % sizes.length], i & 0xff);
+				assert.deepStrictEqual(fs.readFileSync(`${mountPoint}/f${i}.txt`), expected, `content mismatch at f${i}.txt`);
+			}
+		} finally {
 			vfs.umount(mountPoint);
 		}
 	});


### PR DESCRIPTION
This fixes a regression of #224. `rotateMetadata()` could place a metadata block at an unaligned offset, and another `SharedArrayBuffer` writer could advance `used_bytes` between padding and block allocation.

The padding and metadata block are now reserved in one compare-and-exchange loop, with the offset recalculated when another writer gets there first. Tests cover both uneven file sizes and a concurrent allocation.
