### PR TITLE
Truncate the data, not only the inode

### DIFF
--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -335,9 +335,9 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 
 		// A new size on a file is a truncate, and without this the inode reports it while the data node keeps whatever it had.
 		// Only on a file: a directory's data is its listing, and `crossCopy` touches one with the size it just read.
-		if (isFile(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
+		if (!isDirectory(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
 			const data = (await tx.get(inode.data)) ?? new Uint8Array();
-			await tx.set(inode.data, metadata.size < data.byteLength ? data.slice(0, metadata.size) : extendBuffer(data, metadata.size));
+			await tx.set(inode.data, metadata.size < data.byteLength ? data.subarray(0, metadata.size) : extendBuffer(data, metadata.size));
 		}
 
 		if (inode.update(metadata)) {
@@ -353,9 +353,9 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 
 		const inode = this.findInodeSync(tx, path);
 
-		if (isFile(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
+		if (!isDirectory(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
 			const data = tx.getSync(inode.data) ?? new Uint8Array();
-			tx.setSync(inode.data, metadata.size < data.byteLength ? data.slice(0, metadata.size) : extendBuffer(data, metadata.size));
+			tx.setSync(inode.data, metadata.size < data.byteLength ? data.subarray(0, metadata.size) : extendBuffer(data, metadata.size));
 		}
 
 		if (inode.update(metadata)) {

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -333,9 +333,6 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 		await using tx = this.transaction();
 		const inode = await this.findInode(tx, path);
 
-		// A new size is a truncate, and without this the inode reports it while the data node keeps whatever it had.
-		// Not on a directory: its data is its listing, and `crossCopy` touches one with the size it just read.
-		// The cut is scrubbed before the view narrows, since `subarray` leaves those bytes in the buffer for `extendBuffer` to hand back on the regrow.
 		if (!isDirectory(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
 			const data = (await tx.get(inode.data)) ?? new Uint8Array();
 			if (metadata.size < data.byteLength) data.fill(0, metadata.size);

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -333,10 +333,12 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 		await using tx = this.transaction();
 		const inode = await this.findInode(tx, path);
 
-		// A new size on a file is a truncate, and without this the inode reports it while the data node keeps whatever it had.
-		// Only on a file: a directory's data is its listing, and `crossCopy` touches one with the size it just read.
+		// A new size is a truncate, and without this the inode reports it while the data node keeps whatever it had.
+		// Not on a directory: its data is its listing, and `crossCopy` touches one with the size it just read.
+		// The cut is scrubbed before the view narrows, since `subarray` leaves those bytes in the buffer for `extendBuffer` to hand back on the regrow.
 		if (!isDirectory(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
 			const data = (await tx.get(inode.data)) ?? new Uint8Array();
+			if (metadata.size < data.byteLength) data.fill(0, metadata.size);
 			await tx.set(inode.data, metadata.size < data.byteLength ? data.subarray(0, metadata.size) : extendBuffer(data, metadata.size));
 		}
 
@@ -355,6 +357,7 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 
 		if (!isDirectory(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
 			const data = tx.getSync(inode.data) ?? new Uint8Array();
+			if (metadata.size < data.byteLength) data.fill(0, metadata.size);
 			tx.setSync(inode.data, metadata.size < data.byteLength ? data.subarray(0, metadata.size) : extendBuffer(data, metadata.size));
 		}
 

--- a/src/backends/store/fs.ts
+++ b/src/backends/store/fs.ts
@@ -333,6 +333,13 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 		await using tx = this.transaction();
 		const inode = await this.findInode(tx, path);
 
+		// A new size on a file is a truncate, and without this the inode reports it while the data node keeps whatever it had.
+		// Only on a file: a directory's data is its listing, and `crossCopy` touches one with the size it just read.
+		if (isFile(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
+			const data = (await tx.get(inode.data)) ?? new Uint8Array();
+			await tx.set(inode.data, metadata.size < data.byteLength ? data.slice(0, metadata.size) : extendBuffer(data, metadata.size));
+		}
+
 		if (inode.update(metadata)) {
 			this._add(inode.ino, path);
 			tx.setSync(inode.ino, inode);
@@ -345,6 +352,11 @@ export class StoreFS<T extends Store = Store> extends FileSystem {
 		using tx = this.transaction();
 
 		const inode = this.findInodeSync(tx, path);
+
+		if (isFile(inode) && metadata.size !== undefined && metadata.size !== inode.size) {
+			const data = tx.getSync(inode.data) ?? new Uint8Array();
+			tx.setSync(inode.data, metadata.size < data.byteLength ? data.slice(0, metadata.size) : extendBuffer(data, metadata.size));
+		}
 
 		if (inode.update(metadata)) {
 			this._add(inode.ino, path);

--- a/tests/fs/truncate.test.ts
+++ b/tests/fs/truncate.test.ts
@@ -34,7 +34,7 @@ suite('Truncating', config('truncate'), () => {
 		fs.closeSync(fd);
 	});
 
-	test('Contents follow the size', config('sync'), () => {
+	test('Contents follow the size #313', config('sync'), () => {
 		const path = 'truncate-contents.txt';
 		fs.writeFileSync(path, 'SECRETDATA');
 
@@ -77,7 +77,7 @@ suite('Truncating', config('truncate'), () => {
 		await handle.close();
 	});
 
-	test('Contents follow the size (async)', config('async'), async () => {
+	test('Contents follow the size (async) #313', config('async'), async () => {
 		const path = 'truncate-contents-async.txt';
 		await fs.promises.writeFile(path, 'SECRETDATA');
 

--- a/tests/fs/truncate.test.ts
+++ b/tests/fs/truncate.test.ts
@@ -41,7 +41,6 @@ suite('Truncating', config('truncate'), () => {
 		fs.truncateSync(path, 4);
 		assert.equal(fs.readFileSync(path, 'utf8'), 'SECR');
 
-		// Growing back reads as NULs, never the bytes the shrink cut off
 		fs.truncateSync(path, 10);
 		assert.equal(fs.readFileSync(path, 'utf8'), 'SECR\0\0\0\0\0\0');
 	});

--- a/tests/fs/truncate.test.ts
+++ b/tests/fs/truncate.test.ts
@@ -34,6 +34,18 @@ suite('Truncating', config('truncate'), () => {
 		fs.closeSync(fd);
 	});
 
+	test('Contents follow the size', config('sync'), () => {
+		const path = 'truncate-contents.txt';
+		fs.writeFileSync(path, 'SECRETDATA');
+
+		fs.truncateSync(path, 4);
+		assert.equal(fs.readFileSync(path, 'utf8'), 'SECR');
+
+		// Growing back reads as NULs, never the bytes the shrink cut off
+		fs.truncateSync(path, 10);
+		assert.equal(fs.readFileSync(path, 'utf8'), 'SECR\0\0\0\0\0\0');
+	});
+
 	const statSize = async (path: string) => (await fs.promises.stat(path)).size;
 
 	test('Async path functions', config('async'), async () => {
@@ -63,5 +75,16 @@ suite('Truncating', config('truncate'), () => {
 		assert.equal(await statSize(path), 0);
 
 		await handle.close();
+	});
+
+	test('Contents follow the size (async)', config('async'), async () => {
+		const path = 'truncate-contents-async.txt';
+		await fs.promises.writeFile(path, 'SECRETDATA');
+
+		await fs.promises.truncate(path, 4);
+		assert.equal(await fs.promises.readFile(path, 'utf8'), 'SECR');
+
+		await fs.promises.truncate(path, 10);
+		assert.equal(await fs.promises.readFile(path, 'utf8'), 'SECR\0\0\0\0\0\0');
 	});
 });


### PR DESCRIPTION
`StoreFS.touch` writes the metadata it is given and never touches the data node behind it, so a `size` moves the inode and leaves the bytes where they were. Both directions are wrong, and one of them discloses data.

Shrinking is the disclosure. `truncate(f, 4)` then `truncate(f, 10)` reads back as the original ten bytes rather than four and six NULs — the cut bytes were never removed, and the second call moves `size` back past them. `O_TRUNC` followed by a short write is that sequence, so a file overwritten with less than it held hands back the tail of what it held. Growing an untouched file is the same defect facing the other way: the extension has to read as zeroes.

    import { fs, InMemory, mount, resolveMountConfig } from '@zenfs/core';
    mount('/mem', await resolveMountConfig({ backend: InMemory, name: 'r' }));
    fs.writeFileSync('/mem/f', 'SECRETDATA');
    fs.truncateSync('/mem/f', 4);
    fs.truncateSync('/mem/f', 10);
    String(fs.readFileSync('/mem/f'))   // "SECRETDATA", not "SECR\0\0\0\0\0\0"

Only for a regular file, and that is load-bearing: a directory's data node is its serialized listing, and `Async.crossCopy` touches a directory with the size it has just read from it. Treating that as a truncate empties the listing and the tree stops being readable mid-preload.

`IndexFS` is deliberately not touched. Its data lives in the backend rather than in a data node, so the resize is the backend's — `WebAccessFS` already overrides `touch` to truncate the OPFS file. What that backend could not fix for itself is its sync cache, which is a `StoreFS`, and this is what makes the cached size and the cached bytes agree again.